### PR TITLE
Kuis SaSS code

### DIFF
--- a/frontend/app/explore/explore.component.scss
+++ b/frontend/app/explore/explore.component.scss
@@ -42,7 +42,7 @@
       }
       &:hover::after, &:focus::after {
         opacity: 1;
-        transform: translateY(0px);
+        transform: translateY(0);
       }
     }
   }
@@ -92,7 +92,7 @@
     position: absolute;
     width: 100%;
     background-color: rgba(0, 0, 0, 0.5);
-    bottom: 0px;
+    bottom: 0;
 
     h3, p {
       margin: 20px 5px;

--- a/frontend/app/explore/explore.component.scss
+++ b/frontend/app/explore/explore.component.scss
@@ -114,60 +114,12 @@
 
       span {
         margin: 0 5px;
+        cursor: pointer;
+
+        &:hover {
+          color: $button-color-default;
+        }
       }
     }
   }
 }
-
-// .glyphicon {
-//   color: $text-color;
-
-//   &.glyphicon-eye-open, &.glyphicon-list,&.eye-small, &.list-small{
-//     position: absolute;
-//     top: 27px;
-//     left: 880px;
-
-//     &:hover{
-//       cursor: pointer;
-//       color: $button-color-default;
-//     }
-
-//     &.glyphicon-list{
-//       left: 920px;
-//     }
-
-//     &.eye-small{
-//       left: 400px;
-//     }
-
-//     &.list-small{
-//       left: 440px;
-//     }
-//   }
-
-//   &.glyphicon-circle-arrow-right{
-//     top: 4px;
-//   }
-// }
-
-// .shadow-small {
-//   top: 198px;
-// }
-
-// .shadow {
-//   top: 465px;
-// }
-
-// .more-series{
-//   font-size: 1.5em;
-//   position: absolute;
-//   top: 30px;
-//   left: 750px;
-//   color: white;
-
-//   &:hover{
-//     text-decoration: none;
-//     opacity: 0.7;
-//   }
-// }
-

--- a/frontend/app/home/home.component.scss
+++ b/frontend/app/home/home.component.scss
@@ -29,13 +29,12 @@
 
 .imagecontainer { 
   height: 1200px;
-  overflow: none;
+  overflow: hidden;
   z-index: 1;
 
   .imagecontainer_wrapper {
     position: absolute;
     z-index: -1;
-    overflow: hidden;
     display: flex;
     align-items: center;
     overflow: hidden;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,8 +44,21 @@ gulp.task("html", () =>
 
 gulp.task("scss", () =>
     gulp.src(paths.scss)
-        .pipe(sass().on('error', sass.logError))
-        .pipe(csslint())
+        .pipe(sass().on('warning', () => {
+            throw sass.log;
+        }))
+        .pipe(csslint({
+            "important": false,
+            "order-alphabetical": false,
+            "adjoining-classes": false,
+            "ids": false,
+            "import": false,
+            "empty-rules": false,
+            "fallback-colors": false,
+            "qualified-headings": false,
+            "unique-headings": false,
+            "overqualified-elements": false
+        }))
         .pipe(csslint.formatter())
 );
 
@@ -71,9 +84,9 @@ gulp.task("js", () =>
 gulp.task("node", () =>
     gulp.src(paths.node)
         .pipe(jshint({esnext: true}))
-        .pipe(jsreporter)
 );
 
 gulp.task("copy-libs", () =>
-    gulp.src(paths.libs.SRC).pipe(gulp.dest(paths.libs.DEST))
+    gulp.src(paths.libs.SRC)
+        .pipe(gulp.dest(paths.libs.DEST))
 );


### PR DESCRIPTION
- SaSS code opgekuist
- Gulp regels i- of uitgeschakeld zoals:
  - Verplicht alfabetische volgorde is uit
  - lege rijen is uit `.foo { }` is nu verboden
  - rest zie code.
  - **Documentatie:** https://github.com/CSSLint/csslint/wiki/Rules
- Commentaar weg gedaan vanuit SCSS code en hover effect voor iconen